### PR TITLE
fix(declarative): Make `isDeclarative` flag optional

### DIFF
--- a/Sources/InstantSearchTelemetry/TelemetrySchema+Decoding.swift
+++ b/Sources/InstantSearchTelemetry/TelemetrySchema+Decoding.swift
@@ -13,6 +13,22 @@ public enum TelemetrySchemaDecodingError: Error {
   case unzipFailure(Error)
 }
 
+extension TelemetrySchemaDecodingError: LocalizedError {
+  
+  public var errorDescription: String? {
+    switch self {
+    case .base64DecodingFailure:
+      return "Base64 decoding failed"
+    case .deserializationError(let error):
+      return "Telemetry decoding failed: \(error.localizedDescription)"
+    case .unzipFailure(let error):
+      return "Unzip failed: \(error.localizedDescription)"
+    }
+  }
+  
+}
+
+
 public extension TelemetrySchema {
   
   init(gzippedBase64String input: String) throws {

--- a/Sources/InstantSearchTelemetry/telemetry.pb.swift
+++ b/Sources/InstantSearchTelemetry/telemetry.pb.swift
@@ -499,7 +499,6 @@ extension Com_Algolia_Instantsearch_Telemetry_Component: SwiftProtobuf.Message, 
   public var isInitialized: Bool {
     if self._type == nil {return false}
     if self._isConnector == nil {return false}
-    if self._isDeclarative == nil {return false}
     return true
   }
 

--- a/Tests/InstantSearchTelemetryTests/TelemetryTests.swift
+++ b/Tests/InstantSearchTelemetryTests/TelemetryTests.swift
@@ -1,6 +1,26 @@
 import XCTest
 @testable import InstantSearchTelemetry
 
+extension TelemetrySchema {
+  
+  /// Generates a random TelemetrySchema object
+  static func random() -> Self {
+    TelemetrySchema.with {
+      $0.components = Array(TelemetryComponentType.allCases.map { type in
+        TelemetryComponent.with { w in
+          w.type = type
+          w.isConnector = Bool.random()
+          w.isDeclarative = Bool.random()
+          w.parameters = Array(TelemetryComponentParams.allCases.shuffled().prefix((1..<10).randomElement()!))
+        }
+      }
+        .shuffled()
+        .prefix((1..<10).randomElement()!))
+    }
+  }
+  
+}
+
 final class TelemetryTests: XCTestCase {
   
   func testEncodeDecode() throws {
@@ -34,46 +54,46 @@ final class TelemetryTests: XCTestCase {
   }
   
   func testStringDecoding() throws {
-    let rawTelemetryStrings = [
-      "H4sIAAAAAAAAE3ukLXRAlfEECDGdUGU7oap1QZXxkTbbAVXWC6oMj7Q5D6hynFDVBgsC2YJICoTBCoAMEaAIABhKRiRIAAAA",
-      "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExmCFMTguqDICAIzMnTMkAAAA",
-      "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExhC+oMoIAGuHg1AbAAAA",
-      "H4sIAAAAAAAAE3ukzXZAlfmCKgMAAAIDWgkAAAA=",
-      "H4sIAAAAAAAAE3ukzX9AlfEECDGdUGW7oMrwSJvtgCormMFzQJXjhCr7CVUJmLggjCECZAAAlZEs0zwAAAA=",
-      "H4sIAAAAAAAAAHukzXZAlfWCKsMjEIMRzOA8oMpxQlXigiojAP1WSJgeAAAA",
-      "H4sIAAAAAAAAE3ukzXZAlfWCKgMA3F1ofwkAAAA=",
-      "H4sIAAAAAAAAE3ukzX9AlfEECDGdUGW7oMrwSJvtgCormMFzQJXthCrnCVXJC6qMj7Q5D6hynFDVBrOBajhhigVhDCGYlDCMIQJkAADFQJdBYwAAAA==",
-      "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExhC+oMoIZrCCRTgPqHKcUJUACgIAjBiI0jAAAAA=",
+    // After each schema change, a list of encoded telemetry payloads might be added to this map
+    // to test potential decoding regressions
+    let versionedStrings = [
+      "0.1.2": [
+        "H4sIAAAAAAAAE3ukLXRAlfEECDGdUGU7oap1QZXxkTbbAVXWC6oMj7Q5D6hynFDVBgsC2YJICoTBCoAMEaAIABhKRiRIAAAA",
+        "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExmCFMTguqDICAIzMnTMkAAAA",
+        "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExhC+oMoIAGuHg1AbAAAA",
+        "H4sIAAAAAAAAE3ukzXZAlfmCKgMAAAIDWgkAAAA=",
+        "H4sIAAAAAAAAE3ukzXNAVfCEKt8JVZkLqgyPtNkOqIpcUGUEAJ/elTUYAAAA",
+        "H4sIAAAAAAAAE3ukzX9AlfEECDGdUGW7oMrwSJvtgCormMFzQJXjhCr7CVUJmLggjCECZAAAlZEs0zwAAAA=",
+        "H4sIAAAAAAAAAHukzXZAlfWCKsMjEIMRzOA8oMpxQlXigiojAP1WSJgeAAAA",
+        "H4sIAAAAAAAAE3ukzXZAlfWCKgMA3F1ofwkAAAA=",
+        "H4sIAAAAAAAAE3ukzX9AlfEECDGdUGW7oMrwSJvtgCormMFzQJXthCrnCVXJC6qMj7Q5D6hynFDVBrOBajhhigVhDCGYlDCMIQJkAADFQJdBYwAAAA==",
+        "H4sIAAAAAAAAAHukzXZAlfGCKsMjEEMExhC+oMoIZrCCRTgPqHKcUJUACgIAjBiI0jAAAAA=",
+      ],
+      "0.1.3": [
+        "H4sIAAAAAAAAE3ukzXlAleOCKuMNVcZH2mwHVDkvgBhAQWmYIJDNckGV4YYqA5jNBGEDAGxxFME5AAAA",
+        "H4sIAAAAAAAAE02PuQ6DMBAFIaeUA5RDhNxCYiCR8/+1y1dSpuZLYi9CSmet582+7V3l2YpSFKIVU3EUM7EUr47kS9pHJhVz8RQr4UQu3orBmzFJ764+ps7iY1gQJqLuSO039+xtRTNOAr8zVSUy4y8hPtpKH+PtsEIcQp+/MplNCiszUTSvzXMfmdqzEQs7JDwe5jlZKkSyAfsBrWPsTvwAAAA=",
+        "H4sIAAAAAAAAE03Muw6CQAAFUSFigxF8EE2IFsDEx/5/v+WUlNT7JSqGxHZyz02hjWylkYOcBRmkGMkmshSaSC6dXOUk67/+2beykZ3kc1+lMESOcpFe7lLKU+r5+SavhVfxa/fy+ME3DQXcuocAAAA=",
+        "H4sIAAAAAAAAEz4n2rgbAAAA",
+        "H4sIAAAAAAAAE2m9uRgqAAAA",
+        "H4sIAAAAAAAAEzWNuwrCQADAroIOiqj1VRXFikHk/P/5xowdO/dLvJ64hpAM8ZlYyUFecpSLbOQjb9nJvCP0hCE2aeStnGSRedY6qp5qiHUiyES28ih+hjnbSC1r2ctdopxl5igv/9otMS3NazHzgpJqf98vrj2JFJ8AAAA=",
+        "H4sIAAAAAAAAE02MOwqDQABE3WARiRASsAm6ZpGXFN6/3/KVltaeRFcIBIZhmN82p0wrD+nladEXmaSRsBBWwjZ3mZd85H0W0s+Pmc6CY5LkK3cZJf4VbjJY+Eg5H2q5LlQr1Q4DswNgfgAAAA==",
+        "H4sIAAAAAAAAEzXKwQpAQBRGYROyESWiTLM7oXn//V3+S0vr+yRClt/peG6NWqwn4aLwh72ofiZjFptIYheLOEQU5TsEz4Mxikk0ovviDXEz8YBUAAAA",
+        "H4sIAAAAAAAAEzWMuQoCMQAFs3iBghfIrieiTiH5/z7llFta50tMIrbvzUyOt8RW3nKVQaKcZSlhpPsQcjwkTvKUh2zk3vYuxyFVslhH6a2R+UhoV2nO5CJT2cmqMYsC/919YmJl1vL6WV9Y+2TtigAAAA==",
+        "H4sIAAAAAAAAE/cCUoAtAAAA",
+        "H4sIAAAAAAAAEzWOsQ7CMAxEEwEDUIREJYpU2gUeAoX/nz3e2JE5X0LiKpIX++7dOafR2Iut+IhJbMRO9AvxR8zpYvR+6UTyY8jpZnUt8xYHEcXQpNlq1EucxdPB4rmL00Jo7NHrvuLhntGl6OxQnGIWOHhdX2psZwSPql1/vz+QXroAAAA=",
+      ]
     ]
     
-    for (index, string) in rawTelemetryStrings.enumerated() {
-      
-      guard let compressedData = Data(base64Encoded: string) else {
-        XCTFail("Base64 decoding failed: \(index)")
-        return
+    for (version, strings) in versionedStrings {
+      for (index, string) in strings.enumerated() {
+        do {
+          let _ = try TelemetrySchema(gzippedBase64String: string)
+        } catch let error {
+          XCTFail("version: \(version) string \(index) - \(error.localizedDescription)")
+        }
       }
-      
-      let uncompressedData: Data
-      do {
-        uncompressedData = try compressedData.gunzipped()
-      } catch let unzipError {
-        XCTFail("Unzip failed  [\(index)]: \(unzipError)")
-        return
-      }
-      
-      do {
-        _ = try TelemetrySchema(serializedData: uncompressedData)
-      } catch let deserializationError {
-        XCTFail("Telemetry decoding failed [\(index)]: \(deserializationError)")
-        return
-      }
-      
     }
-  }
-  
-  func testDecode() throws {
-    let string = "H4sIAAAAAAAAE3ukzXNAVfCEKt8JVZkLqgyPtNkOqIpcUGUEAJ/elTUYAAAA"
-    let _ = try TelemetrySchema(gzippedBase64String: string)
-  }
 
+  }
+    
 }

--- a/telemetry.proto
+++ b/telemetry.proto
@@ -14,10 +14,10 @@ message Component {
   // WARNING: a default value decoded when value is missing
   repeated ComponentParam parameters = 601;
   required bool isConnector = 602;
-  required bool isDeclarative = 603;
+  optional bool isDeclarative = 603;
 }
 
-// serial name 'com.algolia.instantsearch.telemetry.ComponentType'
+// serial name 'ComponentType'
 enum ComponentType {
   Unknown = 0;
   HitsSearcher = 1;
@@ -49,7 +49,7 @@ enum ComponentType {
   FilterList = 27;
 }
 
-// serial name 'com.algolia.instantsearch.telemetry.ComponentParam'
+// serial name 'ComponentParam'
 enum ComponentParam {
   Undefined = 0;
   ApiKey = 1;

--- a/telemetry/src/commonMain/kotlin/com/algolia/instantsearch/telemetry/Component.kt
+++ b/telemetry/src/commonMain/kotlin/com/algolia/instantsearch/telemetry/Component.kt
@@ -8,5 +8,5 @@ public data class Component(
     @ProtoNumber(600) val type: ComponentType,
     @ProtoNumber(601) val parameters: Set<ComponentParam> = emptySet(),
     @ProtoNumber(602) val isConnector: Boolean,
-    @ProtoNumber(603) val isDeclarative: Boolean,
+    @ProtoNumber(603) val isDeclarative: Boolean?,
 )


### PR DESCRIPTION
Setting the `isDeclarative` component flag `required` breaks the compatibility with telemetry encoded with previous version of the specification. 
This PR makes it `optional` and adds a regression test to make sure the decoding works well for both schemas.